### PR TITLE
Refactor CRLF line ending conversion function

### DIFF
--- a/src/str.rs
+++ b/src/str.rs
@@ -97,12 +97,12 @@ impl Display for SmtpString {
     }
 }
 
-/// Replaces all line endings in the given string with CRLF-style endings (`\r\n`).
+/// Replaces all line endings in the given string with `CRLF`-style endings (`"\r\n"`).
 ///
-/// This will preserve pre-existing `\r\n` characters while replacing the following cases:
-/// - `\r` -> `\r\n`
-/// - `\n` -> `\r\n`
-/// - `\n\r` -> `\r\n\r\n`
+/// This will preserve pre-existing `"\r\n"` characters while replacing the following cases:
+/// - `'\r'` -> `"\r\n"`
+/// - `'\n'` -> `"\r\n"`
+/// - `"\n\r"` -> `"\r\n\r\n"`
 ///
 /// If the original string does not need to be modified, this function will not allocate.
 fn replace_endings_with_crlf(string: &AsciiStr) -> Cow<AsciiStr> {

--- a/src/str.rs
+++ b/src/str.rs
@@ -18,7 +18,7 @@
 
 use std::{borrow::Cow, fmt::Display};
 
-use ascii::{AsAsciiStrError, AsciiChar, AsciiStr, AsciiString, IntoAsciiString};
+use ascii::{AsAsciiStr, AsAsciiStrError, AsciiChar, AsciiStr, AsciiString};
 
 pub const CR: char = '\r';
 pub const LF: char = '\n';
@@ -60,8 +60,8 @@ impl SmtpString {
     /// # }
     /// ```
     pub fn new(str: &str) -> Result<Self, AsAsciiStrError> {
-        let str = str.into_ascii_string().map_err(|e| e.ascii_error())?;
-        let str = self::replace_endings_with_crlf(&str).into_owned();
+        let str = str.as_ascii_str()?;
+        let str = self::replace_endings_with_crlf(str).into_owned();
 
         Ok(Self { str })
     }


### PR DESCRIPTION
Refactors the implementation of `SmtpString`'s CRLF conversion function to (typically) require less re-allocations.

The new function has the following major differences when compared to the prior implementation:
- The function does not allocate if the input does not need to be modified.
- Instead of re-building the string character-by-character, the added characters are inserted directly into the output string.
- This new method should typically be faster, only allocating when new characters are inserted.
    - This is opposed to the previous solution of re-allocating intermittently whilst building the output string.
    - This change does, however, come at the cost of potentially being *more* expensive, most notably in cases where the input string has a lot of invalid line endings or is excessively long in general.
- The function signature has been changed from `fn(&str) -> String` to `fn(&AsciiStr) -> Cow<AsciiStr>`. Relying entirely on ASCII-compliant characters simplifies some computation and may marginally improve performance.

This also slightly changes the internals of the `SmtpString::new` function, applying the conversion *after* transforming the input into ASCII instead of before.

Currently, the output of this function is being directly transformed from a `Cow<AsciiStr>` into an `AsciiString` using `Cow::into_owned`. In the future, once this project is further along in development, it may be a good idea to consider reworking the internals of `SmtpString` to skip this allocation, but for now it should be fine to ignore as it is most likely relatively small and cheap.